### PR TITLE
PostAggregators

### DIFF
--- a/Sources/DataTransferObjects/Query/Aggregator.swift
+++ b/Sources/DataTransferObjects/Query/Aggregator.swift
@@ -2,6 +2,8 @@
 
 import Foundation
 
+/// You can use aggregations at query time to summarize result data.
+/// 
 /// https://druid.apache.org/docs/latest/querying/aggregations.html
 public indirect enum Aggregator: Codable, Hashable {
     // Exact aggregations

--- a/Sources/DataTransferObjects/Query/Aggregator.swift
+++ b/Sources/DataTransferObjects/Query/Aggregator.swift
@@ -117,7 +117,7 @@ public indirect enum Aggregator: Codable, Hashable {
     case filtered(FilteredAggregator)
 
     // Not implemented
-    // case javaScript: JavaScript aggregator
+    // case javaScript: JavaScript aggregator (missing on purpose)
 
     enum CodingKeys: String, CodingKey {
         case type

--- a/Sources/DataTransferObjects/Query/CustomQuery.swift
+++ b/Sources/DataTransferObjects/Query/CustomQuery.swift
@@ -5,7 +5,8 @@ public struct CustomQuery: Codable, Hashable, Equatable {
     public init(queryType: CustomQuery.QueryType, dataSource: String = "telemetry-signals",
                 descending: Bool? = nil, filter: Filter? = nil, intervals: [QueryTimeInterval]? = nil,
                 relativeIntervals: [RelativeTimeInterval]? = nil, granularity: CustomQuery.Granularity,
-                aggregations: [Aggregator]? = nil, limit: Int? = nil, context: QueryContext? = nil,
+                aggregations: [Aggregator]? = nil, postAggregations: [PostAggregator]? = nil,
+                limit: Int? = nil, context: QueryContext? = nil,
                 threshold: Int? = nil, metric: TopNMetricSpec? = nil,
                 dimension: DimensionSpec? = nil, dimensions: [DimensionSpec]? = nil)
     {
@@ -17,6 +18,7 @@ public struct CustomQuery: Codable, Hashable, Equatable {
         self.relativeIntervals = relativeIntervals
         self.granularity = granularity
         self.aggregations = aggregations
+        self.postAggregations = postAggregations
         self.limit = limit
         self.context = context
         self.threshold = threshold
@@ -58,6 +60,7 @@ public struct CustomQuery: Codable, Hashable, Equatable {
     public var relativeIntervals: [RelativeTimeInterval]?
     public let granularity: Granularity
     public var aggregations: [Aggregator]?
+    public var postAggregations: [PostAggregator]?
     public var limit: Int?
     public var context: QueryContext?
 

--- a/Sources/DataTransferObjects/Query/PostAggregator.swift
+++ b/Sources/DataTransferObjects/Query/PostAggregator.swift
@@ -1,0 +1,11 @@
+// swiftlint:disable cyclomatic_complexity
+
+import Foundation
+
+/// Post-aggregations are specifications of processing that should happen on aggregated values as they come out of the timeseries DB.
+/// If you include a post aggregation as part of a query, make sure to include all aggregators the post-aggregator requires.
+/// 
+/// https://druid.apache.org/docs/latest/querying/post-aggregations.html
+public indirect enum PostAggregator: Codable, Hashable {
+    case test
+}

--- a/Sources/DataTransferObjects/Query/PostAggregator.swift
+++ b/Sources/DataTransferObjects/Query/PostAggregator.swift
@@ -11,13 +11,16 @@ public indirect enum PostAggregator: Codable, Hashable {
     case fieldAccess(FieldAccessPostAggregator)
     case finalizingFieldAccess(FieldAccessPostAggregator)
     case constant(ConstantPostAggregator)
-//    case expression
-//    case doubleGreatest
-//    case longGreatest
-//    case doubleMax
-//    case doubleLeast
-//    case longLeast
+    case doubleGreatest(GreatestLeastPostAggregator)
+    case longGreatest(GreatestLeastPostAggregator)
+    case doubleMax(GreatestLeastPostAggregator)
+    case doubleLeast(GreatestLeastPostAggregator)
+    case longLeast(GreatestLeastPostAggregator)
+    // - Expression post-aggregator
 //    case hyperUniqueCardinality
+    
+    // Not implemented by design
+    // - JavaScript post-aggregator
     
     enum CodingKeys: String, CodingKey {
         case type
@@ -36,6 +39,16 @@ public indirect enum PostAggregator: Codable, Hashable {
             self = .fieldAccess(try FieldAccessPostAggregator(from: decoder))
         case "constant":
             self = .constant(try ConstantPostAggregator(from: decoder))
+        case "doubleGreatest":
+            self = .doubleGreatest(try GreatestLeastPostAggregator(from: decoder))
+        case "longGreatest":
+            self = .longGreatest(try GreatestLeastPostAggregator(from: decoder))
+        case "doubleMax":
+            self = .doubleMax(try GreatestLeastPostAggregator(from: decoder))
+        case "doubleLeast":
+            self = .doubleLeast(try GreatestLeastPostAggregator(from: decoder))
+        case "longLeast":
+            self = .longLeast(try GreatestLeastPostAggregator(from: decoder))
         default:
             throw EncodingError.invalidValue("Invalid type", .init(codingPath: [CodingKeys.type], debugDescription: "Invalid Type: \(type)", underlyingError: nil))
         }
@@ -57,6 +70,21 @@ public indirect enum PostAggregator: Codable, Hashable {
         case let .constant(postAggregator):
             try container.encode("constant", forKey: .type)
             try postAggregator.encode(to: encoder)
+        case let .doubleGreatest(postAggregator):
+            try container.encode("doubleGreatest", forKey: .type)
+            try postAggregator.encode(to: encoder)
+        case let .longGreatest(postAggregator):
+            try container.encode("longGreatest", forKey: .type)
+            try postAggregator.encode(to: encoder)
+        case let .doubleMax(postAggregator):
+            try container.encode("doubleMax", forKey: .type)
+            try postAggregator.encode(to: encoder)
+        case let .doubleLeast(postAggregator):
+            try container.encode("doubleLeast", forKey: .type)
+            try postAggregator.encode(to: encoder)
+        case let .longLeast(postAggregator):
+            try container.encode("longLeast", forKey: .type)
+            try postAggregator.encode(to: encoder)
         }
     }
 }
@@ -73,8 +101,6 @@ public enum PostAggregatorType: String, Codable, Hashable {
     case doubleLeast
     case longLeast
     case hyperUniqueCardinality
-
-    // JavaScript post-aggregator not implemented on purpose
 }
 
 /// Arithmetic post-aggregator
@@ -167,3 +193,19 @@ public struct ConstantPostAggregator: Codable, Hashable {
     /// The value to return
     public let value: Double
 }
+
+public struct GreatestLeastPostAggregator: Codable, Hashable {
+    public init(type: PostAggregatorType, name: String, fields: [PostAggregator]) {
+        self.type = type
+        self.name = name
+        self.fields = fields
+    }
+    
+    public let type: PostAggregatorType
+    
+    /// The output name for the aggregated value
+    public let name: String
+
+    public let fields: [PostAggregator]
+}
+

--- a/Sources/DataTransferObjects/Query/PostAggregator.swift
+++ b/Sources/DataTransferObjects/Query/PostAggregator.swift
@@ -16,8 +16,8 @@ public indirect enum PostAggregator: Codable, Hashable {
     case doubleMax(GreatestLeastPostAggregator)
     case doubleLeast(GreatestLeastPostAggregator)
     case longLeast(GreatestLeastPostAggregator)
+    case hyperUniqueCardinality(HyperUniqueCardinalityPostAggregator)
     // - Expression post-aggregator
-//    case hyperUniqueCardinality
     
     // Not implemented by design
     // - JavaScript post-aggregator
@@ -49,6 +49,8 @@ public indirect enum PostAggregator: Codable, Hashable {
             self = .doubleLeast(try GreatestLeastPostAggregator(from: decoder))
         case "longLeast":
             self = .longLeast(try GreatestLeastPostAggregator(from: decoder))
+        case "hyperUniqueCardinality":
+            self = .hyperUniqueCardinality(try HyperUniqueCardinalityPostAggregator(from: decoder))
         default:
             throw EncodingError.invalidValue("Invalid type", .init(codingPath: [CodingKeys.type], debugDescription: "Invalid Type: \(type)", underlyingError: nil))
         }
@@ -84,6 +86,9 @@ public indirect enum PostAggregator: Codable, Hashable {
             try postAggregator.encode(to: encoder)
         case let .longLeast(postAggregator):
             try container.encode("longLeast", forKey: .type)
+            try postAggregator.encode(to: encoder)
+        case let .hyperUniqueCardinality(postAggregator):
+            try container.encode("hyperUniqueCardinality", forKey: .type)
             try postAggregator.encode(to: encoder)
         }
     }
@@ -209,3 +214,18 @@ public struct GreatestLeastPostAggregator: Codable, Hashable {
     public let fields: [PostAggregator]
 }
 
+/// The hyperUniqueCardinality post aggregator is used to wrap a hyperUnique object such that it can be used in post aggregations.
+public struct HyperUniqueCardinalityPostAggregator: Codable, Hashable {
+    public init(name: String? = nil, fieldName: String) {
+        self.type = .hyperUniqueCardinality
+        self.name = name
+        self.fieldName = fieldName
+    }
+    
+    public let type: PostAggregatorType
+    
+    /// The output name for the aggregated value
+    public let name: String?
+
+    public let fieldName: String
+}

--- a/Sources/DataTransferObjects/Query/PostAggregator.swift
+++ b/Sources/DataTransferObjects/Query/PostAggregator.swift
@@ -7,7 +7,6 @@ import Foundation
 ///
 /// https://druid.apache.org/docs/latest/querying/post-aggregations.html
 public indirect enum PostAggregator: Codable, Hashable {
-    
     // Included
     case arithmetic(ArithmetricPostAggregator)
     case fieldAccess(FieldAccessPostAggregator)
@@ -181,7 +180,6 @@ public struct ArithmetricPostAggregator: Codable, Hashable {
     public let ordering: PostAggregatorOrdering?
 }
 
-
 /// Field accessor post-aggregators
 ///
 /// These post-aggregators return the value produced by the specified aggregator.
@@ -284,10 +282,10 @@ public struct ThetaSketchEstimatePostAggregator: Codable, Hashable {
 }
 
 public struct ThetaSketchSetOpPostAggregator: Codable, Hashable {
-    public init(name: String? = nil, `func`: ThetaSketchSetOpPostAggregator.SketchOperation, fields: [PostAggregator]) {
+    public init(name: String? = nil, func: ThetaSketchSetOpPostAggregator.SketchOperation, fields: [PostAggregator]) {
         self.type = .thetaSketchSetOp
         self.name = name
-        self.`func` = `func`
+        self.func = `func`
         self.fields = fields
     }
     

--- a/Sources/DataTransferObjects/Query/PostAggregator.swift
+++ b/Sources/DataTransferObjects/Query/PostAggregator.swift
@@ -4,8 +4,166 @@ import Foundation
 
 /// Post-aggregations are specifications of processing that should happen on aggregated values as they come out of the timeseries DB.
 /// If you include a post aggregation as part of a query, make sure to include all aggregators the post-aggregator requires.
-/// 
+///
 /// https://druid.apache.org/docs/latest/querying/post-aggregations.html
 public indirect enum PostAggregator: Codable, Hashable {
-    case test
+    case arithmetic(ArithmetricPostAggregator)
+    case fieldAccess(FieldAccessPostAggregator)
+    case finalizingFieldAccess(FieldAccessPostAggregator)
+    case constant(ConstantPostAggregator)
+//    case expression
+//    case doubleGreatest
+//    case longGreatest
+//    case doubleMax
+//    case doubleLeast
+//    case longLeast
+//    case hyperUniqueCardinality
+    
+    enum CodingKeys: String, CodingKey {
+        case type
+    }
+
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try values.decode(String.self, forKey: .type)
+        
+        switch type {
+        case "arithmetic":
+            self = .arithmetic(try ArithmetricPostAggregator(from: decoder))
+        case "fieldAccess":
+            self = .fieldAccess(try FieldAccessPostAggregator(from: decoder))
+        case "finalizingFieldAccess":
+            self = .fieldAccess(try FieldAccessPostAggregator(from: decoder))
+        case "constant":
+            self = .constant(try ConstantPostAggregator(from: decoder))
+        default:
+            throw EncodingError.invalidValue("Invalid type", .init(codingPath: [CodingKeys.type], debugDescription: "Invalid Type: \(type)", underlyingError: nil))
+        }
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        
+        switch self {
+        case let .arithmetic(postAggregator):
+            try container.encode("arithmetic", forKey: .type)
+            try postAggregator.encode(to: encoder)
+        case let .fieldAccess(postAggregator):
+            try container.encode("fieldAccess", forKey: .type)
+            try postAggregator.encode(to: encoder)
+        case let .finalizingFieldAccess(postAggregator):
+            try container.encode("finalizingFieldAccess", forKey: .type)
+            try postAggregator.encode(to: encoder)
+        case let .constant(postAggregator):
+            try container.encode("constant", forKey: .type)
+            try postAggregator.encode(to: encoder)
+        }
+    }
+}
+
+public enum PostAggregatorType: String, Codable, Hashable {
+    case arithmetic
+    case fieldAccess
+    case finalizingFieldAccess
+    case constant
+    case expression
+    case doubleGreatest
+    case longGreatest
+    case doubleMax
+    case doubleLeast
+    case longLeast
+    case hyperUniqueCardinality
+
+    // JavaScript post-aggregator not implemented on purpose
+}
+
+/// Arithmetic post-aggregator
+///
+/// The arithmetic post-aggregator applies the provided function to the given fields from left to right. The fields can be aggregators or other post aggregators.
+///
+/// Supported functions are +, -, *, /, and quotient.
+///
+/// Note:
+///
+/// - / division always returns 0 if dividing by 0, regardless of the numerator.
+/// - quotient division behaves like regular floating point division
+/// - Arithmetic post-aggregators always use floating point arithmetic.
+/// - Arithmetic post-aggregators may also specify an ordering, which defines the order of resulting values when sorting results (this can be useful for topN queries for instance)
+///
+/// Arithmetic post-aggregators may also specify an ordering, which defines the order of resulting values when sorting results (this can be useful for topN queries for instance):
+///
+/// - If no ordering (or null) is specified, the default floating point ordering is used.
+/// - numericFirst ordering always returns finite values first, followed by NaN, and infinite values last.
+public struct ArithmetricPostAggregator: Codable, Hashable {
+    public init(name: String, function: MathematicalFunction, fields: [PostAggregator], ordering: Ordering? = nil) {
+        self.type = .arithmetic
+        self.name = name
+        self.fn = function
+        self.fields = fields
+        self.ordering = ordering
+    }
+
+    public enum MathematicalFunction: String, Codable, Hashable {
+        case addition = "+"
+        case subtraction = "-"
+        case multiplication = "*"
+        case division = "/"
+        case quotient
+    }
+    
+    public enum Ordering: String, Codable, Hashable {
+        case numericFirst
+    }
+
+    public let type: PostAggregatorType
+
+    /// The output name for the aggregated value
+    public let name: String
+
+    public let fn: MathematicalFunction
+    
+    public let fields: [PostAggregator]
+    
+    public let ordering: Ordering?
+}
+
+
+/// Field accessor post-aggregators
+///
+/// These post-aggregators return the value produced by the specified aggregator.
+///
+/// fieldName refers to the output name of the aggregator given in the aggregations portion of the query. For complex aggregators, like "cardinality" and
+/// "hyperUnique", the type of the post-aggregator determines what the post-aggregator will return. Use type "fieldAccess" to return the raw aggregation
+/// object, or use type "finalizingFieldAccess" to return a finalized value, such as an estimated cardinality.
+public struct FieldAccessPostAggregator: Codable, Hashable {
+    public init(type: PostAggregatorType, name: String, fieldName: String) {
+        self.type = type
+        self.name = name
+        self.fieldName = fieldName
+    }
+    
+    public let type: PostAggregatorType
+    
+    /// The output name for the aggregated value
+    public let name: String
+    
+    /// An aggregator name
+    public let fieldName: String
+}
+
+/// The constant post-aggregator always returns the specified value.
+public struct ConstantPostAggregator: Codable, Hashable {
+    public init(name: String, value: Double) {
+        self.type = .constant
+        self.name = name
+        self.value = value
+    }
+    
+    public let type: PostAggregatorType
+    
+    /// The output name for the aggregated value
+    public let name: String
+    
+    /// The value to return
+    public let value: Double
 }

--- a/Tests/DataTransferObjectsTests/PostAggregatorTests.swift
+++ b/Tests/DataTransferObjectsTests/PostAggregatorTests.swift
@@ -139,9 +139,11 @@ final class PostAggregatorTests: XCTestCase {
 
         XCTAssertEqual(decodedAggregators, [
             PostAggregator.arithmetic(.init(
-                name: "part_percentage",
-                function: .multiplication,
+                name: "average",
+                function: .division,
                 fields: [
+                    .fieldAccess(.init(type: .fieldAccess, name: "tot", fieldName: "tot")),
+                    .fieldAccess(.init(type: .fieldAccess, name: "rows", fieldName: "rows"))
                 ]
             ))
         ])

--- a/Tests/DataTransferObjectsTests/PostAggregatorTests.swift
+++ b/Tests/DataTransferObjectsTests/PostAggregatorTests.swift
@@ -38,7 +38,22 @@ final class PostAggregatorTests: XCTestCase {
 
         let decodedAggregators = try JSONDecoder.telemetryDecoder.decode([PostAggregator].self, from: examplePostAggregatorThetaSketchEstimate)
 
-        XCTAssertEqual(decodedAggregators, [PostAggregator.arithmetic(ArithmetricPostAggregator(name: "part_percentage", function: .multiplication, fields: []))])
+        XCTAssertEqual(
+            decodedAggregators,
+            [
+                .thetaSketchEstimate(.init(
+                    name: "app_launched_and_data_entered_count",
+                    field: .thetaSketchSetOp(.init(
+                        name: "app_launched_and_data_entered_count",
+                        func: .intersect,
+                        fields: [
+                            .fieldAccess(.init(type: .fieldAccess, fieldName: "appLaunchedByNotification_count")),
+                            .fieldAccess(.init(type: .fieldAccess, fieldName: "dataEntered_count")),
+                        ]
+                    ))
+                ))
+            ]
+        )
     }
 
     func testPercentageArithmeticDecoding() throws {
@@ -136,21 +151,21 @@ final class PostAggregatorTests: XCTestCase {
         ])
     }
 
-    let exampleHyperUnique = """
-    [{
-        "type"   : "arithmetic",
-        "name"   : "average_users_per_row",
-        "fn"     : "/",
-        "fields" : [
-          { "type" : "hyperUniqueCardinality", "fieldName" : "unique_users" },
-          { "type" : "fieldAccess", "name" : "rows", "fieldName" : "rows" }
-        ]
-      }]
-    """
-    .filter { !$0.isWhitespace }
-    .data(using: .utf8)!
-
     func testHyperUniqueDecoding() throws {
+        let exampleHyperUnique = """
+        [{
+            "type"   : "arithmetic",
+            "name"   : "average_users_per_row",
+            "fn"     : "/",
+            "fields" : [
+              { "type" : "hyperUniqueCardinality", "fieldName" : "unique_users" },
+              { "type" : "fieldAccess", "name" : "rows", "fieldName" : "rows" }
+            ]
+          }]
+        """
+        .filter { !$0.isWhitespace }
+        .data(using: .utf8)!
+
         let decodedAggregators = try JSONDecoder.telemetryDecoder.decode([PostAggregator].self, from: exampleHyperUnique)
 
         XCTAssertEqual(decodedAggregators, [

--- a/Tests/DataTransferObjectsTests/PostAggregatorTests.swift
+++ b/Tests/DataTransferObjectsTests/PostAggregatorTests.swift
@@ -48,7 +48,7 @@ final class PostAggregatorTests: XCTestCase {
                         func: .intersect,
                         fields: [
                             .fieldAccess(.init(type: .fieldAccess, fieldName: "appLaunchedByNotification_count")),
-                            .fieldAccess(.init(type: .fieldAccess, fieldName: "dataEntered_count")),
+                            .fieldAccess(.init(type: .fieldAccess, fieldName: "dataEntered_count"))
                         ]
                     ))
                 ))

--- a/Tests/DataTransferObjectsTests/PostAggregatorTests.swift
+++ b/Tests/DataTransferObjectsTests/PostAggregatorTests.swift
@@ -9,85 +9,60 @@
 import XCTest
 
 final class PostAggregatorTests: XCTestCase {
-    let examplePostAggregatorThetaSketchEstimate = """
-    [
-      {
-        "type": "thetaSketchEstimate",
-        "name": "app_launched_and_data_entered_count",
-        "field": {
-          "type": "thetaSketchSetOp",
-          "name": "app_launched_and_data_entered_count",
-          "func": "INTERSECT",
-          "fields": [
-            {
-              "type": "fieldAccess",
-              "fieldName": "appLaunchedByNotification_count"
-            },
-            {
-              "type": "fieldAccess",
-              "fieldName": "dataEntered_count"
-            }
-          ]
-        }
-      }
-    ]
-    """
-    .filter { !$0.isWhitespace }
-    .data(using: .utf8)!
-
-    let examplePostAggregatorArithmetic = """
-    [{
-        "type"   : "arithmetic",
-        "name"   : "average",
-        "fn"     : "/",
-        "fields" : [
-               { "type" : "fieldAccess", "name" : "tot", "fieldName" : "tot" },
-               { "type" : "fieldAccess", "name" : "rows", "fieldName" : "rows" }
-             ]
-      }]
-    """
-    .filter { !$0.isWhitespace }
-    .data(using: .utf8)!
-
-    let examplePostAggregatorPercentage = """
-    [{
-        "type"   : "arithmetic",
-        "name"   : "part_percentage",
-        "fn"     : "*",
-        "fields" : [
-           { "type"   : "arithmetic",
-             "name"   : "ratio",
-             "fn"     : "/",
-             "fields" : [
-               { "type" : "fieldAccess", "name" : "part", "fieldName" : "part" },
-               { "type" : "fieldAccess", "name" : "tot", "fieldName" : "tot" }
-             ]
-           },
-           { "type" : "constant", "name": "const", "value" : 100 }
-        ]
-      }]
-    """
-    .filter { !$0.isWhitespace }
-    .data(using: .utf8)!
-
-    let examplePostAggregatorExpression = """
-    [{
-        "type"       : "expression",
-        "name"       : "part_percentage",
-        "expression" : "100 * (part / tot)"
-      }]
-    """
-    .filter { !$0.isWhitespace }
-    .data(using: .utf8)!
-
-
     func testThetaSketchAggregatorDecoding() throws {
+        let examplePostAggregatorThetaSketchEstimate = """
+        [
+          {
+            "type": "thetaSketchEstimate",
+            "name": "app_launched_and_data_entered_count",
+            "field": {
+              "type": "thetaSketchSetOp",
+              "name": "app_launched_and_data_entered_count",
+              "func": "INTERSECT",
+              "fields": [
+                {
+                  "type": "fieldAccess",
+                  "fieldName": "appLaunchedByNotification_count"
+                },
+                {
+                  "type": "fieldAccess",
+                  "fieldName": "dataEntered_count"
+                }
+              ]
+            }
+          }
+        ]
+        """
+        .filter { !$0.isWhitespace }
+        .data(using: .utf8)!
+
         let decodedAggregators = try JSONDecoder.telemetryDecoder.decode([PostAggregator].self, from: examplePostAggregatorThetaSketchEstimate)
 
         XCTAssertEqual(decodedAggregators, [PostAggregator.arithmetic(ArithmetricPostAggregator(name: "part_percentage", function: .multiplication, fields: []))])
     }
 
     func testPercentageArithmeticDecoding() throws {
+        let examplePostAggregatorPercentage = """
+        [{
+            "type"   : "arithmetic",
+            "name"   : "part_percentage",
+            "fn"     : "*",
+            "fields" : [
+               { "type"   : "arithmetic",
+                 "name"   : "ratio",
+                 "fn"     : "/",
+                 "fields" : [
+                   { "type" : "fieldAccess", "name" : "part", "fieldName" : "part" },
+                   { "type" : "fieldAccess", "name" : "tot", "fieldName" : "tot" }
+                 ]
+               },
+               { "type" : "constant", "name": "const", "value" : 100 }
+            ]
+          }]
+        """
+        .filter { !$0.isWhitespace }
+        .data(using: .utf8)!
+
         let decodedAggregators = try JSONDecoder.telemetryDecoder.decode([PostAggregator].self, from: examplePostAggregatorPercentage)
 
         XCTAssertEqual(
@@ -111,8 +86,56 @@ final class PostAggregatorTests: XCTestCase {
         )
     }
 
-    func testExpressionDecoding() throws {
+    func testPostAggregatorExpressionDecoding() throws {
+        let examplePostAggregatorExpression = """
+        [{
+            "type"       : "expression",
+            "name"       : "part_percentage",
+            "expression" : "100 * (part / tot)"
+          }]
+        """
+        .filter { !$0.isWhitespace }
+        .data(using: .utf8)!
+
         let decodedAggregators = try JSONDecoder.telemetryDecoder.decode([PostAggregator].self, from: examplePostAggregatorExpression)
+
+        XCTAssertEqual(
+            decodedAggregators,
+            [
+                PostAggregator.arithmetic(.init(
+                    name: "part_percentage",
+                    function: .multiplication,
+                    fields: [
+                        .arithmetic(.init(
+                            name: "ratio",
+                            function: .division, fields: [
+                                .fieldAccess(.init(type: .fieldAccess, name: "part", fieldName: "part")),
+                                .fieldAccess(.init(type: .fieldAccess, name: "tot", fieldName: "tot"))
+                            ]
+                        )),
+                        PostAggregator.constant(.init(name: "const", value: 100))
+                    ]
+                ))
+            ]
+        )
+    }
+
+    func testPostAggregatorArithmeticDecoding() throws {
+        let examplePostAggregatorArithmetic = """
+        [{
+            "type"   : "arithmetic",
+            "name"   : "average",
+            "fn"     : "/",
+            "fields" : [
+                   { "type" : "fieldAccess", "name" : "tot", "fieldName" : "tot" },
+                   { "type" : "fieldAccess", "name" : "rows", "fieldName" : "rows" }
+                 ]
+          }]
+        """
+        .filter { !$0.isWhitespace }
+        .data(using: .utf8)!
+
+        let decodedAggregators = try JSONDecoder.telemetryDecoder.decode([PostAggregator].self, from: examplePostAggregatorArithmetic)
 
         XCTAssertEqual(decodedAggregators, [
             PostAggregator.arithmetic(.init(
@@ -123,7 +146,7 @@ final class PostAggregatorTests: XCTestCase {
             ))
         ])
     }
-    
+
     let exampleHyperUnique = """
     [{
         "type"   : "arithmetic",
@@ -137,7 +160,7 @@ final class PostAggregatorTests: XCTestCase {
     """
     .filter { !$0.isWhitespace }
     .data(using: .utf8)!
-    
+
     func testHyperUniqueDecoding() throws {
         let decodedAggregators = try JSONDecoder.telemetryDecoder.decode([PostAggregator].self, from: exampleHyperUnique)
 

--- a/Tests/DataTransferObjectsTests/PostAggregatorTests.swift
+++ b/Tests/DataTransferObjectsTests/PostAggregatorTests.swift
@@ -102,20 +102,7 @@ final class PostAggregatorTests: XCTestCase {
         XCTAssertEqual(
             decodedAggregators,
             [
-                PostAggregator.arithmetic(.init(
-                    name: "part_percentage",
-                    function: .multiplication,
-                    fields: [
-                        .arithmetic(.init(
-                            name: "ratio",
-                            function: .division, fields: [
-                                .fieldAccess(.init(type: .fieldAccess, name: "part", fieldName: "part")),
-                                .fieldAccess(.init(type: .fieldAccess, name: "tot", fieldName: "tot"))
-                            ]
-                        )),
-                        PostAggregator.constant(.init(name: "const", value: 100))
-                    ]
-                ))
+                .expression(.init(name: "part_percentage", expression: "100*(part/tot)"))
             ]
         )
     }

--- a/Tests/DataTransferObjectsTests/PostAggregatorTests.swift
+++ b/Tests/DataTransferObjectsTests/PostAggregatorTests.swift
@@ -79,6 +79,20 @@ final class PostAggregatorTests: XCTestCase {
     """
     .filter { !$0.isWhitespace }
     .data(using: .utf8)!
+    
+    let exampleHyperUnique = """
+    [{
+        "type"   : "arithmetic",
+        "name"   : "average_users_per_row",
+        "fn"     : "/",
+        "fields" : [
+          { "type" : "hyperUniqueCardinality", "fieldName" : "unique_users" },
+          { "type" : "fieldAccess", "name" : "rows", "fieldName" : "rows" }
+        ]
+      }]
+    """
+    .filter { !$0.isWhitespace }
+    .data(using: .utf8)!
 
     func testThetaSketchAggregatorDecoding() throws {
         let decodedAggregators = try JSONDecoder.telemetryDecoder.decode([PostAggregator].self, from: examplePostAggregatorThetaSketchEstimate)
@@ -112,6 +126,19 @@ final class PostAggregatorTests: XCTestCase {
 
     func testExpressionDecoding() throws {
         let decodedAggregators = try JSONDecoder.telemetryDecoder.decode([PostAggregator].self, from: examplePostAggregatorExpression)
+
+        XCTAssertEqual(decodedAggregators, [
+            PostAggregator.arithmetic(.init(
+                name: "part_percentage",
+                function: .multiplication,
+                fields: [
+                ]
+            ))
+        ])
+    }
+    
+    func testHyperUniqueDecoding() throws {
+        let decodedAggregators = try JSONDecoder.telemetryDecoder.decode([PostAggregator].self, from: exampleHyperUnique)
 
         XCTAssertEqual(decodedAggregators, [
             PostAggregator.arithmetic(.init(

--- a/Tests/DataTransferObjectsTests/PostAggregatorTests.swift
+++ b/Tests/DataTransferObjectsTests/PostAggregatorTests.swift
@@ -79,20 +79,7 @@ final class PostAggregatorTests: XCTestCase {
     """
     .filter { !$0.isWhitespace }
     .data(using: .utf8)!
-    
-    let exampleHyperUnique = """
-    [{
-        "type"   : "arithmetic",
-        "name"   : "average_users_per_row",
-        "fn"     : "/",
-        "fields" : [
-          { "type" : "hyperUniqueCardinality", "fieldName" : "unique_users" },
-          { "type" : "fieldAccess", "name" : "rows", "fieldName" : "rows" }
-        ]
-      }]
-    """
-    .filter { !$0.isWhitespace }
-    .data(using: .utf8)!
+
 
     func testThetaSketchAggregatorDecoding() throws {
         let decodedAggregators = try JSONDecoder.telemetryDecoder.decode([PostAggregator].self, from: examplePostAggregatorThetaSketchEstimate)
@@ -137,14 +124,30 @@ final class PostAggregatorTests: XCTestCase {
         ])
     }
     
+    let exampleHyperUnique = """
+    [{
+        "type"   : "arithmetic",
+        "name"   : "average_users_per_row",
+        "fn"     : "/",
+        "fields" : [
+          { "type" : "hyperUniqueCardinality", "fieldName" : "unique_users" },
+          { "type" : "fieldAccess", "name" : "rows", "fieldName" : "rows" }
+        ]
+      }]
+    """
+    .filter { !$0.isWhitespace }
+    .data(using: .utf8)!
+    
     func testHyperUniqueDecoding() throws {
         let decodedAggregators = try JSONDecoder.telemetryDecoder.decode([PostAggregator].self, from: exampleHyperUnique)
 
         XCTAssertEqual(decodedAggregators, [
             PostAggregator.arithmetic(.init(
-                name: "part_percentage",
-                function: .multiplication,
+                name: "average_users_per_row",
+                function: .division,
                 fields: [
+                    .hyperUniqueCardinality(.init(fieldName: "unique_users")),
+                    .fieldAccess(.init(type: .fieldAccess, name: "rows", fieldName: "rows"))
                 ]
             ))
         ])

--- a/Tests/DataTransferObjectsTests/PostAggregatorTests.swift
+++ b/Tests/DataTransferObjectsTests/PostAggregatorTests.swift
@@ -1,0 +1,100 @@
+//
+//  File.swift
+//  
+//
+//  Created by Daniel Jilg on 22.09.22.
+//
+
+@testable import DataTransferObjects
+import XCTest
+
+final class PostAggregatorTests: XCTestCase {
+    let examplePostAggregatorThetaSketchEstimate = """
+    [
+      {
+        "type": "thetaSketchEstimate",
+        "name": "app_launched_and_data_entered_count",
+        "field": {
+          "type": "thetaSketchSetOp",
+          "name": "app_launched_and_data_entered_count",
+          "func": "INTERSECT",
+          "fields": [
+            {
+              "type": "fieldAccess",
+              "fieldName": "appLaunchedByNotification_count"
+            },
+            {
+              "type": "fieldAccess",
+              "fieldName": "dataEntered_count"
+            }
+          ]
+        }
+      }
+    ]
+    """
+    .filter { !$0.isWhitespace }
+    .data(using: .utf8)!
+    
+    let examplePostAggregatorArithmetic = """
+    [{
+        "type"   : "arithmetic",
+        "name"   : "average",
+        "fn"     : "/",
+        "fields" : [
+               { "type" : "fieldAccess", "name" : "tot", "fieldName" : "tot" },
+               { "type" : "fieldAccess", "name" : "rows", "fieldName" : "rows" }
+             ]
+      }]
+    """
+    .filter { !$0.isWhitespace }
+    .data(using: .utf8)!
+    
+    let examplePostAggregatorPercentage = """
+    [{
+        "type"   : "arithmetic",
+        "name"   : "part_percentage",
+        "fn"     : "*",
+        "fields" : [
+           { "type"   : "arithmetic",
+             "name"   : "ratio",
+             "fn"     : "/",
+             "fields" : [
+               { "type" : "fieldAccess", "name" : "part", "fieldName" : "part" },
+               { "type" : "fieldAccess", "name" : "tot", "fieldName" : "tot" }
+             ]
+           },
+           { "type" : "constant", "name": "const", "value" : 100 }
+        ]
+      }]
+    """
+    .filter { !$0.isWhitespace }
+    .data(using: .utf8)!
+    
+    let examplePostAggregatorExpression = """
+    [{
+        "type"       : "expression",
+        "name"       : "part_percentage",
+        "expression" : "100 * (part / tot)"
+      }]
+    """
+    .filter { !$0.isWhitespace }
+    .data(using: .utf8)!
+
+    func testThetaSketchAggregatorDecoding() throws {
+        let decodedAggregators = try JSONDecoder.telemetryDecoder.decode([PostAggregator].self, from: examplePostAggregatorThetaSketchEstimate)
+
+        XCTAssertEqual(decodedAggregators, [PostAggregator.test])
+    }
+    
+    func testPercentageArithmeticDecoding() throws {
+        let decodedAggregators = try JSONDecoder.telemetryDecoder.decode([PostAggregator].self, from: examplePostAggregatorPercentage)
+
+        XCTAssertEqual(decodedAggregators, [PostAggregator.test])
+    }
+    
+    func testExpressionDecoding() throws {
+        let decodedAggregators = try JSONDecoder.telemetryDecoder.decode([PostAggregator].self, from: examplePostAggregatorExpression)
+
+        XCTAssertEqual(decodedAggregators, [PostAggregator.test])
+    }
+}


### PR DESCRIPTION
Post-aggregations are specifications of processing that should happen on aggregated values as they come out of the timeseries DB.

- [ ] Add a `postAggregations` property to CustomQuery
- [x] Add a `PostAggregator` data type


```json
{
  "queryType": "groupBy",
  "dataSource": "telemetry-signals",
  "granularity": "all",
  "dimensions": [],
  "filter": {...},
  "aggregations": [...],
  "postAggregations": [
    {
      "type": "thetaSketchEstimate",
      "name": "app_launched_and_data_entered_count",
      "field": {
        "type": "thetaSketchSetOp",
        "name": "app_launched_and_data_entered_count",
        "func": "INTERSECT",
        "fields": [
          {
            "type": "fieldAccess",
            "fieldName": "appLaunchedByNotification_count"
          },
          {
            "type": "fieldAccess",
            "fieldName": "dataEntered_count"
          }
        ]
      }
    }
  ],
  "relativeIntervals": [...]
}
```