### PR TITLE
Add QueryGranularity struct

### DIFF
--- a/Sources/DataTransferObjects/DTOs/DTOv2.swift
+++ b/Sources/DataTransferObjects/DTOs/DTOv2.swift
@@ -202,7 +202,7 @@ public enum DTOv2 {
         public var breakdownKey: String?
 
         /// If set, group and count found signals by this time interval. Incompatible with breakdownKey
-        public var groupBy: InsightGroupByInterval?
+        public var groupBy: QueryGranularity?
 
         /// How should this insight's data be displayed?
         public var displayMode: InsightDisplayMode
@@ -229,7 +229,7 @@ public enum DTOv2 {
             uniqueUser: Bool,
             filters: [String: String],
             breakdownKey: String?,
-            groupBy: InsightGroupByInterval?,
+            groupBy: QueryGranularity?,
             displayMode: InsightDisplayMode,
             isExpanded: Bool,
             lastRunTime: TimeInterval?,
@@ -423,13 +423,6 @@ public enum InsightDisplayMode: String, Codable {
     case barChart
     case lineChart
     case pieChart
-}
-
-public enum InsightGroupByInterval: String, Codable {
-    case hour
-    case day
-    case week
-    case month
 }
 
 public extension DTOv2.Insight {

--- a/Sources/DataTransferObjects/DTOs/InsightCalculationResult.swift
+++ b/Sources/DataTransferObjects/DTOs/InsightCalculationResult.swift
@@ -32,7 +32,7 @@ public extension DTOv1 {
         public var breakdownKey: String?
 
         /// If set, group and count found signals by this time interval. Incompatible with breakdownKey
-        public var groupBy: InsightGroupByInterval?
+        public var groupBy: QueryGranularity?
 
         /// How should this insight's data be displayed?
         public var displayMode: InsightDisplayMode
@@ -55,7 +55,7 @@ public extension DTOv1 {
     /// Defines the result of an insight calculation
     struct InsightCalculationResult: Identifiable, Codable {
         public init(id: UUID, order: Double?, title: String, signalType: String?, uniqueUser: Bool, filters: [String: String],
-                    rollingWindowSize _: TimeInterval, breakdownKey: String? = nil, groupBy: InsightGroupByInterval? = nil,
+                    rollingWindowSize _: TimeInterval, breakdownKey: String? = nil, groupBy: QueryGranularity? = nil,
                     displayMode: InsightDisplayMode, isExpanded: Bool, data: [DTOv1.InsightData], calculatedAt: Date, calculationDuration: TimeInterval)
         {
             self.id = id
@@ -91,7 +91,7 @@ public extension DTOv1 {
         public var breakdownKey: String?
 
         /// If set, group and count found signals by this time interval. Incompatible with breakdownKey
-        public var groupBy: InsightGroupByInterval?
+        public var groupBy: QueryGranularity?
 
         /// How should this insight's data be displayed?
         public var displayMode: InsightDisplayMode

--- a/Sources/DataTransferObjects/Models.swift
+++ b/Sources/DataTransferObjects/Models.swift
@@ -76,7 +76,7 @@ public struct TelemetryApp: Codable, Hashable, Identifiable {
 public struct InsightDefinitionRequestBody: Codable {
     public init(order: Double? = nil, title: String, signalType: String? = nil, uniqueUser: Bool,
                 filters: [String: String], rollingWindowSize: TimeInterval, breakdownKey: String? = nil,
-                groupBy: InsightGroupByInterval? = nil, displayMode: InsightDisplayMode, groupID: UUID? = nil, id: UUID? = nil, isExpanded: Bool)
+                groupBy: QueryGranularity? = nil, displayMode: InsightDisplayMode, groupID: UUID? = nil, id: UUID? = nil, isExpanded: Bool)
     {
         self.order = order
         self.title = title
@@ -111,7 +111,7 @@ public struct InsightDefinitionRequestBody: Codable {
     public var breakdownKey: String?
 
     /// If set, group and count found signals by this time interval. Incompatible with breakdownKey
-    public var groupBy: InsightGroupByInterval?
+    public var groupBy: QueryGranularity?
 
     /// How should this insight's data be displayed?
     public var displayMode: InsightDisplayMode

--- a/Sources/DataTransferObjects/Query/CustomQuery.swift
+++ b/Sources/DataTransferObjects/Query/CustomQuery.swift
@@ -4,7 +4,7 @@ import Foundation
 public struct CustomQuery: Codable, Hashable, Equatable {
     public init(queryType: CustomQuery.QueryType, dataSource: String = "telemetry-signals",
                 descending: Bool? = nil, filter: Filter? = nil, intervals: [QueryTimeInterval]? = nil,
-                relativeIntervals: [RelativeTimeInterval]? = nil, granularity: CustomQuery.Granularity,
+                relativeIntervals: [RelativeTimeInterval]? = nil, granularity: QueryGranularity,
                 aggregations: [Aggregator]? = nil, postAggregations: [PostAggregator]? = nil,
                 limit: Int? = nil, context: QueryContext? = nil,
                 threshold: Int? = nil, metric: TopNMetricSpec? = nil,
@@ -29,7 +29,7 @@ public struct CustomQuery: Codable, Hashable, Equatable {
     
     public init(queryType: CustomQuery.QueryType, dataSource: DataSource = .init(type: .table, name: "telemetry-signals"),
                 descending: Bool? = nil, filter: Filter? = nil, intervals: [QueryTimeInterval]? = nil,
-                relativeIntervals: [RelativeTimeInterval]? = nil, granularity: CustomQuery.Granularity,
+                relativeIntervals: [RelativeTimeInterval]? = nil, granularity: QueryGranularity,
                 aggregations: [Aggregator]? = nil, postAggregations: [PostAggregator]? = nil,
                 limit: Int? = nil, context: QueryContext? = nil,
                 threshold: Int? = nil, metric: TopNMetricSpec? = nil,
@@ -60,52 +60,6 @@ public struct CustomQuery: Codable, Hashable, Equatable {
         case topN
     }
 
-    public enum Granularity: String, Codable, Hashable, CaseIterable {
-        case all
-        case none
-        case second
-        case minute
-        case fifteen_minute
-        case thirty_minute
-        case hour
-        case day
-        case week
-        case month
-        case quarter
-        case year
-        
-        enum CodingKeys: String, CodingKey {
-            case type
-        }
-        
-        public init(from decoder: Decoder) throws {
-            let type: String
-            
-            let singleValueContainer = try decoder.singleValueContainer()
-            if let singleValueType = try? singleValueContainer.decode(String.self) {
-                type = singleValueType
-            }
-            
-            else {
-                let keyedContainer = try decoder.container(keyedBy: CodingKeys.self)
-                type = try keyedContainer.decode(String.self, forKey: .type)
-            }
-            
-            for possibleCase in Self.allCases {
-                if type == possibleCase.rawValue {
-                    self = possibleCase
-                    return
-                }
-            }
-            
-            throw DecodingError.dataCorrupted(.init(
-                codingPath: [],
-                debugDescription: "needs to be a string or a dict",
-                underlyingError: nil
-            ))
-        }
-    }
-
     public var queryType: QueryType
     public var dataSource: DataSource = .init(type: .table, name: "telemetry-signals")
     public var descending: Bool?
@@ -114,7 +68,7 @@ public struct CustomQuery: Codable, Hashable, Equatable {
 
     /// If a relative intervals are set, their calculated output replaces the regular intervals
     public var relativeIntervals: [RelativeTimeInterval]?
-    public let granularity: Granularity
+    public let granularity: QueryGranularity
     public var aggregations: [Aggregator]?
     public var postAggregations: [PostAggregator]?
     public var limit: Int?
@@ -161,7 +115,7 @@ public struct CustomQuery: Codable, Hashable, Equatable {
         self.descending = try container.decodeIfPresent(Bool.self, forKey: CustomQuery.CodingKeys.descending)
         self.filter = try container.decodeIfPresent(Filter.self, forKey: CustomQuery.CodingKeys.filter)
         self.relativeIntervals = try container.decodeIfPresent([RelativeTimeInterval].self, forKey: CustomQuery.CodingKeys.relativeIntervals)
-        self.granularity = try container.decode(CustomQuery.Granularity.self, forKey: CustomQuery.CodingKeys.granularity)
+        self.granularity = try container.decode(QueryGranularity.self, forKey: CustomQuery.CodingKeys.granularity)
         self.aggregations = try container.decodeIfPresent([Aggregator].self, forKey: CustomQuery.CodingKeys.aggregations)
         self.postAggregations = try container.decodeIfPresent([PostAggregator].self, forKey: CustomQuery.CodingKeys.postAggregations)
         self.limit = try container.decodeIfPresent(Int.self, forKey: CustomQuery.CodingKeys.limit)

--- a/Sources/DataTransferObjects/Query/QueryGranularity.swift
+++ b/Sources/DataTransferObjects/Query/QueryGranularity.swift
@@ -1,0 +1,45 @@
+public enum QueryGranularity: String, Codable, Hashable, CaseIterable {
+    case all
+    case none
+    case second
+    case minute
+    case fifteen_minute
+    case thirty_minute
+    case hour
+    case day
+    case week
+    case month
+    case quarter
+    case year
+    
+    enum CodingKeys: String, CodingKey {
+        case type
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let type: String
+        
+        let singleValueContainer = try decoder.singleValueContainer()
+        if let singleValueType = try? singleValueContainer.decode(String.self) {
+            type = singleValueType
+        }
+        
+        else {
+            let keyedContainer = try decoder.container(keyedBy: CodingKeys.self)
+            type = try keyedContainer.decode(String.self, forKey: .type)
+        }
+        
+        for possibleCase in Self.allCases {
+            if type == possibleCase.rawValue {
+                self = possibleCase
+                return
+            }
+        }
+        
+        throw DecodingError.dataCorrupted(.init(
+            codingPath: [],
+            debugDescription: "needs to be a string or a dict",
+            underlyingError: nil
+        ))
+    }
+}


### PR DESCRIPTION
This struct is applicable everywhere a granularity is expected, such as Insight.groupby and CustomQuery.granularity. It replaces various implementations of the same concept.