### PR TITLE
Support TimeBoundary Query Type

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -45,8 +45,8 @@ file_length:
 type_name:
   min_length: 4 # only warning
   max_length: # warning and error
-    warning: 40
-    error: 50
+    warning: 80
+    error: 100
   excluded:
     - App
   allowed_symbols: ["_"] # these are allowed in type names

--- a/Sources/DataTransferObjects/Chart Configuration/ChartConfigurationOptions.swift
+++ b/Sources/DataTransferObjects/Chart Configuration/ChartConfigurationOptions.swift
@@ -135,11 +135,17 @@ public struct AxisOptions: Codable, Equatable {
     public enum AxisType: String, Codable, Equatable {
         /// Numerical axis, suitable for continuous data.
         case value
+
         /// Category axis, suitable for discrete category data.
         case category
-        /// Time axis, suitable for continuous time series data. As compared to value axis, it has a better formatting for time and a different tick calculation method. For example, it decides to use month, week, day or hour for tick based on the range of span.
+
+        /// Time axis, suitable for continuous time series data. As compared to value axis, it has a better formatting for time and a
+        /// different tick calculation method. For example, it decides to use month, week, day or hour for tick based on the range of
+        /// span.
         case time
-        /// Log axis, suitable for log data. Stacked bar or line series with type: 'log' axes may lead to significant visual errors and may have unintended effects in certain circumstances. Their use should be avoided.
+
+        /// Log axis, suitable for log data. Stacked bar or line series with type: 'log' axes may lead to significant visual errors and
+        /// may have unintended effects in certain circumstances. Their use should be avoided.
         case log
     }
 }

--- a/Sources/DataTransferObjects/Query/CustomQuery.swift
+++ b/Sources/DataTransferObjects/Query/CustomQuery.swift
@@ -142,6 +142,7 @@ public struct CustomQuery: Codable, Hashable, Equatable {
         case groupBy
         case topN
         case scan
+        case timeBoundary
 
         // derived types
         case funnel

--- a/Sources/DataTransferObjects/Query/Virtual Column/ExpressionVirtualColumn.swift
+++ b/Sources/DataTransferObjects/Query/Virtual Column/ExpressionVirtualColumn.swift
@@ -7,10 +7,8 @@ public struct ExpressionVirtualColumn: Codable, Hashable, Equatable {
         self.expression = expression
         self.outputType = outputType
     }
-    
+
     public let name: String
     public let expression: String
     public let outputType: String?
 }
-
-

--- a/Sources/DataTransferObjects/Query/Virtual Column/ListFilteredVirtualColumn.swift
+++ b/Sources/DataTransferObjects/Query/Virtual Column/ListFilteredVirtualColumn.swift
@@ -1,4 +1,5 @@
-/// This virtual column provides an alternative way to use 'list filtered' dimension spec as a virtual column. It has optimized access to the underlying column value indexes that can provide a small performance improvement in some cases.
+/// This virtual column provides an alternative way to use 'list filtered' dimension spec as a virtual column. It has optimized access
+/// to the underlying column value indexes that can provide a small performance improvement in some cases.
 public struct ListFilteredVirtualColumn: Codable, Hashable, Equatable {
     public init(name: String, delegate: String, values: [String], isAllowList: Bool? = nil) {
         self.name = name

--- a/Tests/QueryTests/CustomQueryTests.swift
+++ b/Tests/QueryTests/CustomQueryTests.swift
@@ -413,6 +413,33 @@ final class CustomQueryTests: XCTestCase {
         XCTAssertEqual(expectedOutput, String(data: encodedOutput, encoding: .utf8)!)
     }
 
+    func testTimeBoundaryQueryDecoding() throws {
+        let input = """
+         {
+           "queryType": "timeBoundary",
+           "dataSource": "wikipedia"
+         }
+        """.data(using: .utf8)!
+
+        let expectedOutput = CustomQuery(queryType: .timeBoundary, dataSource: "wikipedia")
+
+        let decodedOutput = try JSONDecoder.telemetryDecoder.decode(CustomQuery.self, from: input)
+
+        XCTAssertEqual(expectedOutput, decodedOutput)
+    }
+
+    func testTimeBoundaryQueryEncoding() throws {
+        let input = CustomQuery(queryType: .timeBoundary, dataSource: "wikipedia")
+
+        let expectedOutput = """
+        {"dataSource":"wikipedia","queryType":"timeBoundary"}
+        """
+
+        let encodedOutput = try JSONEncoder.telemetryEncoder.encode(input)
+
+        XCTAssertEqual(expectedOutput, String(data: encodedOutput, encoding: .utf8)!)
+    }
+
     func testChartConfiguration() throws {
         let customQuery = CustomQuery(
             queryType: .timeseries,


### PR DESCRIPTION
Druid recently added a new query type called `timeBoundary` which will return the earliest and latest occurrence of a filter.  This might be helpful with some AARRR topics, so I'm tagging @Jeehut and @Julian-TMD here. 

```json
{
    "queryType" : "timeBoundary",
    "dataSource": "sample_datasource",
    "filter"    : { "type": "and", "fields": [<filter>, <filter>, ...] }
}
```

Results in 

```json
[ {
  "timestamp" : "2013-05-09T18:24:00.000Z",
  "result" : {
    "minTime" : "2013-05-09T18:24:00.000Z",
    "maxTime" : "2013-05-09T18:37:00.000Z"
  }
} ]
```