### PR TITLE
Add infrastructure for convenience aggregators and post-aggregators

### DIFF
--- a/Sources/DataTransferObjects/Query/Aggregator.swift
+++ b/Sources/DataTransferObjects/Query/Aggregator.swift
@@ -7,9 +7,15 @@ import Foundation
 /// https://druid.apache.org/docs/latest/querying/aggregations.html
 public indirect enum Aggregator: Codable, Hashable, Equatable {
     // Convenience Aggregators
+
     /// Counts the number of unique users in a query.
     case userCount(UserCountAggregator)
+
+    /// Counts the number of unique events in a query.
     case eventCount(EventCountAggregator)
+
+    // Produces a histogram over a numerical value (floatValue by default)
+    case histogram(HistogramAggregator)
 
     // Exact aggregations
 
@@ -142,6 +148,8 @@ public indirect enum Aggregator: Codable, Hashable, Equatable {
             self = try .userCount(UserCountAggregator(from: decoder))
         case "eventCount":
             self = try .eventCount(EventCountAggregator(from: decoder))
+        case "histogram":
+            self = try .histogram(HistogramAggregator(from: decoder))
         case "count":
             self = try .count(CountAggregator(from: decoder))
         case "cardinality":
@@ -211,6 +219,9 @@ public indirect enum Aggregator: Codable, Hashable, Equatable {
             try selector.encode(to: encoder)
         case let .eventCount(selector):
             try container.encode("eventCount", forKey: .type)
+            try selector.encode(to: encoder)
+        case let .histogram(selector):
+            try container.encode("histogram", forKey: .type)
             try selector.encode(to: encoder)
         case let .count(selector):
             try container.encode("count", forKey: .type)
@@ -303,6 +314,8 @@ public indirect enum Aggregator: Codable, Hashable, Equatable {
             return aggregator.precompile()
         case let .eventCount(aggregator):
             return aggregator.precompile()
+        case let .histogram(aggregator):
+            return aggregator.precompile()
         default:
             return nil
         }
@@ -380,6 +393,7 @@ public enum AggregatorType: String, Codable, Hashable {
     // Convenience Aggregators
     case userCount
     case eventCount
+    case histogram
 
     // Native Aggregators
     case count
@@ -515,5 +529,59 @@ public struct EventCountAggregator: Codable, Hashable, PrecompilableAggregator {
         let aggregators = [Aggregator.longSum(.init(type: .longSum, name: "Events", fieldName: "count"))]
 
         return (aggregators: aggregators, postAggregators: [])
+    }
+}
+
+/// Convenience Aggregator that implements a histogram over floatValue using DataSketches Quantiles
+public struct HistogramAggregator: Codable, Hashable, PrecompilableAggregator {
+    public init(name: String? = nil, fieldName: String? = nil, splitPoints: [Double]? = nil, numBins: Int? = nil, k: Int? = nil) {
+        self.name = name
+        self.fieldName = fieldName
+        self.splitPoints = splitPoints
+        self.numBins = numBins
+        self.k = k
+    }
+
+    /// String representing the output column to store sketch values (defaults to "Histogram")
+    public let name: String?
+
+    /// A string for the name of the input field (defaults to `floatvalue`)
+    public let fieldName: String?
+
+    /// array of split points (optional)
+    public let splitPoints: [Double]?
+
+    /// Number of bins (optional, defaults to 10)
+    public let numBins: Int?
+
+    /// Parameter that determines the accuracy and size of the sketch. Higher k means higher accuracy but more space to store
+    /// sketches. Must be a power of 2 from 2 to 32768.
+    ///
+    ///  Defaults to 1024 in the TelemetryDeck implementation
+    public let k: Int?
+
+    public func precompile() -> (aggregators: [Aggregator], postAggregators: [PostAggregator]) {
+        let aggregators = [
+            Aggregator.quantilesDoublesSketch(
+                .init(
+                    name: "_histogramSketch",
+                    fieldName: fieldName ?? "floatValue",
+                    k: k ?? 1024
+                )
+            )
+        ]
+
+        let postAggregators = [
+            PostAggregator.quantilesDoublesSketchToHistogram(
+                .init(
+                    name: name ?? "Histogram",
+                    field: .fieldAccess(.init(type: .fieldAccess, fieldName: "_histogramSketch")),
+                    splitPoints: splitPoints,
+                    numBins: numBins
+                )
+            )
+        ]
+
+        return (aggregators: aggregators, postAggregators: postAggregators)
     }
 }

--- a/Sources/DataTransferObjects/Query/Aggregator.swift
+++ b/Sources/DataTransferObjects/Query/Aggregator.swift
@@ -568,7 +568,9 @@ public struct HistogramAggregator: Codable, Hashable, PrecompilableAggregator {
                     fieldName: fieldName ?? "floatValue",
                     k: k ?? 1024
                 )
-            )
+            ),
+            Aggregator.longMin(.init(type: .longMin, name: "_quantilesMinValue", fieldName: fieldName ?? "floatValue")),
+            Aggregator.longMax(.init(type: .longMax, name: "_quantilesMaxValue", fieldName: fieldName ?? "floatValue")),
         ]
 
         let postAggregators = [
@@ -579,7 +581,7 @@ public struct HistogramAggregator: Codable, Hashable, PrecompilableAggregator {
                     splitPoints: splitPoints,
                     numBins: numBins
                 )
-            )
+            ),
         ]
 
         return (aggregators: aggregators, postAggregators: postAggregators)

--- a/Sources/DataTransferObjects/Query/Aggregator.swift
+++ b/Sources/DataTransferObjects/Query/Aggregator.swift
@@ -197,6 +197,12 @@ public indirect enum Aggregator: Codable, Hashable, Equatable {
         var container = encoder.container(keyedBy: CodingKeys.self)
 
         switch self {
+        case let .userCount(selector):
+            try container.encode("userCount", forKey: .type)
+            try selector.encode(to: encoder)
+        case let .eventCount(selector):
+            try container.encode("eventCount", forKey: .type)
+            try selector.encode(to: encoder)
         case let .count(selector):
             try container.encode("count", forKey: .type)
             try selector.encode(to: encoder)

--- a/Sources/DataTransferObjects/Query/PostAggregator.swift
+++ b/Sources/DataTransferObjects/Query/PostAggregator.swift
@@ -162,6 +162,14 @@ public indirect enum PostAggregator: Codable, Hashable, Equatable {
             try postAggregator.encode(to: encoder)
         }
     }
+
+    /// Precompile any convenience post-aggregators
+    func precompile() -> (aggregators: [Aggregator], postAggregators: [PostAggregator])? {
+        switch self {
+        default:
+            return nil
+        }
+    }
 }
 
 public enum PostAggregatorType: String, Codable, Hashable {

--- a/Sources/DataTransferObjects/Query/PostAggregator.swift
+++ b/Sources/DataTransferObjects/Query/PostAggregator.swift
@@ -499,7 +499,7 @@ public struct QuantilesDoublesSketchToHistogramPostAggregator: Codable, Hashable
     /// array of split points (optional)
     public let splitPoints: [Double]?
 
-    /// <number of bins (optional, defaults to 10)
+    /// Number of bins (optional, defaults to 10)
     public let numBins: Int?
 }
 

--- a/Sources/DataTransferObjects/QueryGeneration/Precompilable.swift
+++ b/Sources/DataTransferObjects/QueryGeneration/Precompilable.swift
@@ -1,0 +1,13 @@
+/// Marks an aggregator as needing precompilation before it can be used in a query.
+///
+/// Some aggregators require precompilation before they can be used in a query. This is because
+/// they are addons introduced by TQL and not understood by Druid. These aggregators must be
+/// converted into a set of druid native aggregators and post aggregators before they can be used
+/// in a query.
+///
+/// Implement this protocol on your aggregator to indicate that it needs precompilation and return
+/// the set of native aggregators and post aggregators that should be used in place of this
+/// aggregator.
+public protocol PrecompilableAggregator {
+    func precompile() -> (aggregators: [Aggregator], postAggregators: [PostAggregator])
+}

--- a/Tests/QueryGenerationTests/CompileDownTests.swift
+++ b/Tests/QueryGenerationTests/CompileDownTests.swift
@@ -26,13 +26,6 @@ final class CompileDownTests: XCTestCase {
         XCTAssertEqual(precompiledQuery.queryType, .groupBy)
     }
 
-    func testFailIfNoIntervals() throws {
-        // this query has neither a relativeIntervals nor an intervals property
-        let query = CustomQuery(queryType: .timeseries, granularity: .all)
-
-        XCTAssertThrowsError(try query.precompile(organizationAppIDs: [UUID(), UUID()], isSuperOrg: false))
-    }
-
     func testBaseFiltersThisOrganization() throws {
         let query = CustomQuery(queryType: .timeseries, baseFilters: .thisOrganization, relativeIntervals: relativeIntervals, granularity: .all)
         let precompiledQuery = try query.precompile(organizationAppIDs: [appID1, appID2], isSuperOrg: false)

--- a/Tests/QueryGenerationTests/ConvenienceAggregatorTests.swift
+++ b/Tests/QueryGenerationTests/ConvenienceAggregatorTests.swift
@@ -1,0 +1,18 @@
+import DataTransferObjects
+import XCTest
+
+final class ConvenienceAggregatorTests: XCTestCase {
+    func testUserCountQueryGetsPrecompiled() throws {
+        let query = CustomQuery(queryType: .timeseries, aggregations: [.userCount(.init())])
+        let precompiled = try query.precompile(organizationAppIDs: [UUID()], isSuperOrg: false)
+        let expectedAggregations: [Aggregator] = [.thetaSketch(.init(type: .thetaSketch, name: "Users", fieldName: "clientUser"))]
+        XCTAssertEqual(precompiled.aggregations, expectedAggregations)
+    }
+
+    func testEventCountQueryGetsPrecompiled() throws {
+        let query = CustomQuery(queryType: .timeseries, aggregations: [.eventCount(.init())])
+        let precompiled = try query.precompile(organizationAppIDs: [UUID()], isSuperOrg: false)
+        let expectedAggregations: [Aggregator] = [.longSum(.init(type: .longSum, name: "Events", fieldName: "count"))]
+        XCTAssertEqual(precompiled.aggregations, expectedAggregations)
+    }
+}

--- a/Tests/QueryGenerationTests/ConvenienceAggregatorTests.swift
+++ b/Tests/QueryGenerationTests/ConvenienceAggregatorTests.swift
@@ -19,7 +19,11 @@ final class ConvenienceAggregatorTests: XCTestCase {
     func testHistogramQueryGetsPrecompiled() throws {
         let query = CustomQuery(queryType: .timeseries, aggregations: [.histogram(.init())])
         let precompiled = try query.precompile(organizationAppIDs: [UUID()], isSuperOrg: false)
-        let expectedAggregations: [Aggregator] = [.quantilesDoublesSketch(.init(name: "_histogramSketch", fieldName: "floatValue", k: 1024, maxStreamLength: nil, shouldFinalize: nil))]
+        let expectedAggregations: [Aggregator] = [
+            .quantilesDoublesSketch(.init(name: "_histogramSketch", fieldName: "floatValue", k: 1024, maxStreamLength: nil, shouldFinalize: nil)),
+            .longMin(.init(type: .longMin, name: "_quantilesMinValue", fieldName: "floatValue")),
+            .longMax(.init(type: .longMax, name: "_quantilesMaxValue", fieldName: "floatValue")),
+        ]
         let expectedPostAggregations: [PostAggregator] = [.quantilesDoublesSketchToHistogram(
             .init(
                 name: "Histogram",
@@ -32,4 +36,3 @@ final class ConvenienceAggregatorTests: XCTestCase {
         XCTAssertEqual(precompiled.postAggregations, expectedPostAggregations)
     }
 }
-

--- a/Tests/QueryGenerationTests/ConvenienceAggregatorTests.swift
+++ b/Tests/QueryGenerationTests/ConvenienceAggregatorTests.swift
@@ -15,4 +15,21 @@ final class ConvenienceAggregatorTests: XCTestCase {
         let expectedAggregations: [Aggregator] = [.longSum(.init(type: .longSum, name: "Events", fieldName: "count"))]
         XCTAssertEqual(precompiled.aggregations, expectedAggregations)
     }
+
+    func testHistogramQueryGetsPrecompiled() throws {
+        let query = CustomQuery(queryType: .timeseries, aggregations: [.histogram(.init())])
+        let precompiled = try query.precompile(organizationAppIDs: [UUID()], isSuperOrg: false)
+        let expectedAggregations: [Aggregator] = [.quantilesDoublesSketch(.init(name: "_histogramSketch", fieldName: "floatValue", k: 1024, maxStreamLength: nil, shouldFinalize: nil))]
+        let expectedPostAggregations: [PostAggregator] = [.quantilesDoublesSketchToHistogram(
+            .init(
+                name: "Histogram",
+                field: .fieldAccess(.init(type: .fieldAccess, name: nil, fieldName: "_histogramSketch")),
+                splitPoints: nil,
+                numBins: nil
+            )
+        )]
+        XCTAssertEqual(precompiled.aggregations, expectedAggregations)
+        XCTAssertEqual(precompiled.postAggregations, expectedPostAggregations)
+    }
 }
+

--- a/Tests/QueryTests/AggregatorTests.swift
+++ b/Tests/QueryTests/AggregatorTests.swift
@@ -294,4 +294,46 @@ final class AggregatorTests: XCTestCase {
         let encodedAggregators = try JSONEncoder.telemetryEncoder.encode(swiftRepresentation)
         XCTAssertEqual(String(data: encodedAggregators, encoding: .utf8)!, stringRepresentation)
     }
+
+    func testHistogramAggregatorWithDefaults() throws {
+        let stringRepresentation = """
+        [
+            {
+              "type": "histogram"
+            }
+          ]
+        """
+        .filter { !$0.isWhitespace }
+
+        let swiftRepresentation = [Aggregator.histogram(.init())]
+
+        let decodedAggregators = try JSONDecoder.telemetryDecoder.decode([Aggregator].self, from: stringRepresentation.data(using: .utf8)!)
+        XCTAssertEqual(decodedAggregators, swiftRepresentation)
+
+        let encodedAggregators = try JSONEncoder.telemetryEncoder.encode(swiftRepresentation)
+        XCTAssertEqual(String(data: encodedAggregators, encoding: .utf8)!, stringRepresentation)
+    }
+
+    func testHistogramAggregatorWithParameters() throws {
+        let stringRepresentation = """
+        [
+            {
+              "fieldName": "anotherNumericalField",
+              "k": 512,
+              "name": "MyVeryCoolHistogram",
+              "numBins": 25,
+              "type": "histogram"
+            }
+          ]
+        """
+        .filter { !$0.isWhitespace }
+
+        let swiftRepresentation = [Aggregator.histogram(.init(name: "MyVeryCoolHistogram", fieldName: "anotherNumericalField", splitPoints: nil, numBins: 25, k: 512))]
+
+        let decodedAggregators = try JSONDecoder.telemetryDecoder.decode([Aggregator].self, from: stringRepresentation.data(using: .utf8)!)
+        XCTAssertEqual(decodedAggregators, swiftRepresentation)
+
+        let encodedAggregators = try JSONEncoder.telemetryEncoder.encode(swiftRepresentation)
+        XCTAssertEqual(String(data: encodedAggregators, encoding: .utf8)!, stringRepresentation)
+    }
 }

--- a/Tests/QueryTests/AggregatorTests.swift
+++ b/Tests/QueryTests/AggregatorTests.swift
@@ -255,4 +255,43 @@ final class AggregatorTests: XCTestCase {
 
         XCTAssertEqual(String(data: encodedAggregators, encoding: .utf8)!, expectedEncodedAggregators)
     }
+
+
+    func testUserCountAggregator() throws {
+        let stringRepresentation = """
+        [
+            {
+              "type": "userCount"
+            }
+          ]
+        """
+        .filter { !$0.isWhitespace }
+
+        let swiftRepresentation = [Aggregator.userCount(.init())]
+
+        let decodedAggregators = try JSONDecoder.telemetryDecoder.decode([Aggregator].self, from: stringRepresentation.data(using: .utf8)!)
+        XCTAssertEqual(decodedAggregators, swiftRepresentation)
+
+        let encodedAggregators = try JSONEncoder.telemetryEncoder.encode(swiftRepresentation)
+        XCTAssertEqual(String(data: encodedAggregators, encoding: .utf8)!, stringRepresentation)
+    }
+
+    func testEventCountAggregator() throws {
+        let stringRepresentation = """
+        [
+            {
+              "type": "eventCount"
+            }
+          ]
+        """
+        .filter { !$0.isWhitespace }
+
+        let swiftRepresentation = [Aggregator.eventCount(.init())]
+
+        let decodedAggregators = try JSONDecoder.telemetryDecoder.decode([Aggregator].self, from: stringRepresentation.data(using: .utf8)!)
+        XCTAssertEqual(decodedAggregators, swiftRepresentation)
+
+        let encodedAggregators = try JSONEncoder.telemetryEncoder.encode(swiftRepresentation)
+        XCTAssertEqual(String(data: encodedAggregators, encoding: .utf8)!, stringRepresentation)
+    }
 }


### PR DESCRIPTION
This PR introduces infrastructure to be able to introduce more convenience aggregators.

- [x] Create a `userCount` aggregator that abstracts away the thetaSketch over `clientUser` necessary to count users
- [x] Create a `eventCount` aggregator that abstracts away the longSum offer `count` aggregator necessary to count events
- [x] replace a complex system of datasketch aggregator, fieldaccess post-aggregator and histogram post-aggregator with a "histogram" aggregator 

In the future I'm hoping we can use this to gradually and gently extend the language to make it more user-friendly while still being able to access all underlying complexity when necessary. 

These are now valid TQL queries:

## Stacked chart with users and events:

```json
{
  "queryType": "timeseries",
  "granularity": "day",
  "aggregations": [
    { "type": "userCount" },
    { "type": "eventCount" }
  ]
}
```

## Histogram of FloatValue for a signal type

```json
{
  "queryType": "timeseries",
  "granularity": "all",
  "filter": {...}
  "aggregations": [
    { "type": "histogram", "numBins": 20 }
  ]
}
```
