### PR TITLE
Fail when groupBy or topN queries try to use hourly granularity

### DIFF
--- a/Sources/DataTransferObjects/Query/CustomQuery+CompileDown.swift
+++ b/Sources/DataTransferObjects/Query/CustomQuery+CompileDown.swift
@@ -25,6 +25,13 @@ public extension CustomQuery {
             throw QueryGenerationError.compilationStatusError
         }
 
+        // If we're not a super-org, disallow running groupBy and topN queries in hourly granularity
+        // because these currently produce misleading or wrong data sometimes.
+        // Remove this after the issue is fixed.
+        if !isSuperOrg, granularity == .hour, [.topN, .groupBy].contains(queryType) {
+            throw QueryGenerationError.notImplemented(reason: "This query can't be calculated in hourly granularity. Please choose daily or monthly instead.")
+        }
+
         // Make an editable copy of self
         var query = self
 

--- a/Tests/QueryGenerationTests/CompileDownTests.swift
+++ b/Tests/QueryGenerationTests/CompileDownTests.swift
@@ -314,4 +314,46 @@ final class CompileDownTests: XCTestCase {
         let compiledQuery = try precompiledQuery.compileToRunnableQuery()
         XCTAssertEqual(compiledQuery.dataSource?.name, "some-unknown-namespace")
     }
+
+    func testAllowsHourlyGranularityForTimeseries() throws {
+        let intervals: [QueryTimeInterval] = [
+            .init(beginningDate: Date(iso8601String: "2023-04-01T00:00:00.000Z")!, endDate: Date(iso8601String: "2023-05-31T00:00:00.000Z")!),
+        ]
+        let query = CustomQuery(queryType: .timeseries, intervals: intervals, granularity: .hour)
+        XCTAssertNoThrow(try query.precompile(organizationAppIDs: [appID1, appID2], isSuperOrg: false))
+    }
+
+    func testAllowsDailyGranularityForTopN() throws {
+        let intervals: [QueryTimeInterval] = [
+            .init(beginningDate: Date(iso8601String: "2023-04-01T00:00:00.000Z")!, endDate: Date(iso8601String: "2023-05-31T00:00:00.000Z")!),
+        ]
+        let query = CustomQuery(queryType: .topN, intervals: intervals, granularity: .day)
+        XCTAssertNoThrow(try query.precompile(organizationAppIDs: [appID1, appID2], isSuperOrg: false))
+    }
+
+    func testAllowsDailyGranularityForGroupBy() throws {
+        let intervals: [QueryTimeInterval] = [
+            .init(beginningDate: Date(iso8601String: "2023-04-01T00:00:00.000Z")!, endDate: Date(iso8601String: "2023-05-31T00:00:00.000Z")!),
+        ]
+        let query = CustomQuery(queryType: .groupBy, intervals: intervals, granularity: .day)
+        XCTAssertNoThrow(try query.precompile(organizationAppIDs: [appID1, appID2], isSuperOrg: false))
+    }
+
+    func testDisallowsHourlyQueriesForTopN() throws {
+        let intervals: [QueryTimeInterval] = [
+            .init(beginningDate: Date(iso8601String: "2023-04-01T00:00:00.000Z")!, endDate: Date(iso8601String: "2023-05-31T00:00:00.000Z")!),
+        ]
+        let query = CustomQuery(queryType: .topN, intervals: intervals, granularity: .hour)
+
+        XCTAssertThrowsError(try query.precompile(organizationAppIDs: [appID1, appID2], isSuperOrg: false))
+    }
+
+    func testDisallowsHourlyQueriesForGroupBy() throws {
+        let intervals: [QueryTimeInterval] = [
+            .init(beginningDate: Date(iso8601String: "2023-04-01T00:00:00.000Z")!, endDate: Date(iso8601String: "2023-05-31T00:00:00.000Z")!),
+        ]
+        let query = CustomQuery(queryType: .groupBy, intervals: intervals, granularity: .hour)
+
+        XCTAssertThrowsError(try query.precompile(organizationAppIDs: [appID1, appID2], isSuperOrg: false))
+    }
 }


### PR DESCRIPTION
This is not a fix for https://github.com/TelemetryDeck/telemetry/issues/568, but it is a quick change to stop false information from being displayed. This changes the query compilation process to crash when these conditions are met:

1. the caller is not a super org
2. the granularity is hourly
3. and the query type is either topN or groupBy

This way, we can still investigate the problem by running the offending queries as a super org.