### PR TITLE
Result Rows Caching

### DIFF
--- a/Sources/DataTransferObjects/Query/CustomQuery.swift
+++ b/Sources/DataTransferObjects/Query/CustomQuery.swift
@@ -233,6 +233,14 @@ public struct CustomQuery: Codable, Hashable, Equatable {
         return digest.compactMap { String(format: "%02x", $0) }.joined()
     }
 
+    // Return a hash value that is independent of the intervals or relative intervals.
+    public var intervalIndependentHash: String {
+        var query = self
+        query.intervals = nil
+        query.relativeIntervals = nil
+        return query.stableHashValue
+    }
+
     public func hash(into hasher: inout Hasher) {
         hasher.combine(queryType)
         hasher.combine(compilationStatus)

--- a/Sources/DataTransferObjects/Query/QueryTimeInterval.swift
+++ b/Sources/DataTransferObjects/Query/QueryTimeInterval.swift
@@ -6,13 +6,79 @@ public struct QueryTimeIntervalsContainer: Codable, Hashable, Equatable {
         case intervals
     }
 
+    public init(type: QueryTimeIntervalsContainer.ContainerType, intervals: [QueryTimeInterval]) {
+        self.type = type
+        self.intervals = intervals
+    }
+
+    public init(type: QueryTimeIntervalsContainer.ContainerType, timeSegments: [TimeSegment]) throws {
+        self.type = type
+
+        // Sort and deduplicate time segments
+        let timeSegmentsNormalized = Set(timeSegments).sorted { $0.beginningDate < $1.beginningDate }
+
+        if timeSegmentsNormalized.isEmpty {
+            self.intervals = []
+            return
+        }
+
+        var component: Calendar.Component
+        switch timeSegmentsNormalized.first!.duration {
+        case .hour:
+            component = .hour
+        case .day:
+            component = .day
+        case .month:
+            component = .month
+        case .year:
+            component = .year
+        default:
+            throw CustomQuery.QueryGenerationError.compilationStatusError
+        }
+
+        var calendar = Calendar(identifier: .iso8601)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+
+        var intervals = [QueryTimeInterval]()
+        var currentInterval = QueryTimeInterval(beginningDate: timeSegmentsNormalized.first!.beginningDate, endDate: timeSegmentsNormalized.first!.beginningDate)
+
+        for segment in timeSegmentsNormalized {
+            // If the segment is not continouus, create a new interval
+            if try segment.beginningDate > calendar.add(component, to: currentInterval.endDate) {
+                currentInterval.endDate = try calendar.add(component, to: currentInterval.endDate)
+                intervals.append(currentInterval)
+                currentInterval = QueryTimeInterval(beginningDate: segment.beginningDate, endDate: segment.beginningDate)
+            }
+
+            // Extend the current interval
+            if segment.beginningDate > currentInterval.endDate {
+                currentInterval.endDate = segment.beginningDate
+            }
+        }
+        currentInterval.endDate = try calendar.add(component, to: currentInterval.endDate)
+        intervals.append(currentInterval)
+
+        self.intervals = intervals
+    }
+
     public let type: ContainerType
     public let intervals: [QueryTimeInterval]
+
+    public func timeSegments(with granularity: QueryGranularity) throws -> [TimeSegment] {
+        var segments = Set<TimeSegment>()
+
+        for interval in intervals {
+            let intervalSegments = try interval.timeSegments(with: granularity)
+            segments.formUnion(intervalSegments)
+        }
+
+        return segments.sorted { $0.beginningDate < $1.beginningDate }
+    }
 }
 
 public struct QueryTimeInterval: Codable, Hashable, Equatable, Comparable {
-    public let beginningDate: Date
-    public let endDate: Date
+    public var beginningDate: Date
+    public var endDate: Date
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
@@ -109,7 +175,7 @@ public struct QueryTimeInterval: Codable, Hashable, Equatable, Comparable {
         }
 
         while currentDate < endDate {
-            let nextDate = calendar.date(byAdding: component, value: 1, to: currentDate)!
+            let nextDate = try calendar.add(component, to: currentDate)
             let segment = TimeSegment(beginningDate: currentDate, duration: granularity)
             segments.append(segment)
             currentDate = nextDate
@@ -127,4 +193,13 @@ public struct TimeSegment: Codable, Hashable, Equatable {
 
     public let beginningDate: Date
     public let duration: QueryGranularity
+}
+
+extension Calendar {
+    func add(_ component: Calendar.Component, value: Int = 1, to date: Date) throws -> Date {
+        guard let result = self.date(byAdding: component, value: value, to: date) else {
+            throw CustomQuery.QueryGenerationError.compilationStatusError
+        }
+        return result
+    }
 }

--- a/Sources/DataTransferObjects/QueryResult/GroupByQueryResult.swift
+++ b/Sources/DataTransferObjects/QueryResult/GroupByQueryResult.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// GroupBy queries return an array of JSON objects, where each object represents a grouping as described in the group-by query.
+/// For example, we can query for the daily average of a dimension for the past month grouped by another dimension.
+public struct GroupByQueryResult: Codable, Hashable, Equatable {
+    public init(rows: [GroupByQueryResultRow], restrictions: [QueryTimeInterval]? = nil) {
+        self.restrictions = restrictions
+        self.rows = rows
+    }
+
+    public let restrictions: [QueryTimeInterval]?
+    public let rows: [GroupByQueryResultRow]
+}
+
+public struct GroupByQueryResultRow: Codable, Hashable, Equatable {
+    public init(timestamp: Date, event: AdaptableQueryResultItem) {
+        version = "v1"
+        self.timestamp = timestamp
+        self.event = event
+    }
+
+    public let version: String
+    public let timestamp: Date
+    public let event: AdaptableQueryResultItem
+}

--- a/Sources/DataTransferObjects/QueryResult/QueryResult.swift
+++ b/Sources/DataTransferObjects/QueryResult/QueryResult.swift
@@ -54,15 +54,7 @@ public enum QueryResult: Codable, Hashable, Equatable {
     }
 }
 
-public struct TimeSeriesQueryResult: Codable, Hashable, Equatable {
-    public init(rows: [TimeSeriesQueryResultRow], restrictions: [QueryTimeInterval]? = nil) {
-        self.rows = rows
-        self.restrictions = restrictions
-    }
-
-    public let restrictions: [QueryTimeInterval]?
-    public let rows: [TimeSeriesQueryResultRow]
-}
+// MARK: - Query Result Types
 
 /// Wrapper that can resolve either into a String or an Array of Strings
 public enum StringWrapper: Codable, Hashable, Equatable {
@@ -205,106 +197,6 @@ public struct DoublePlusInfinity: Codable, Hashable, Equatable {
     }
 }
 
-/// Time series queries return an array of JSON objects, where each object represents a value as described in the time-series query.
-/// For instance, the daily average of a dimension for the last one month.
-public struct TimeSeriesQueryResultRow: Codable, Hashable, Equatable {
-    public init(timestamp: Date, result: [String: DoubleWrapper]) {
-        self.timestamp = timestamp
-        self.result = result
-    }
-
-    public let timestamp: Date?
-    public let result: [String: DoubleWrapper?]
-}
-
-/// GroupBy queries return an array of JSON objects, where each object represents a grouping as described in the group-by query.
-/// For example, we can query for the daily average of a dimension for the past month grouped by another dimension.
-public struct GroupByQueryResult: Codable, Hashable, Equatable {
-    public init(rows: [GroupByQueryResultRow], restrictions: [QueryTimeInterval]? = nil) {
-        self.restrictions = restrictions
-        self.rows = rows
-    }
-
-    public let restrictions: [QueryTimeInterval]?
-    public let rows: [GroupByQueryResultRow]
-}
-
-public struct GroupByQueryResultRow: Codable, Hashable, Equatable {
-    public init(timestamp: Date, event: AdaptableQueryResultItem) {
-        version = "v1"
-        self.timestamp = timestamp
-        self.event = event
-    }
-
-    public let version: String
-    public let timestamp: Date
-    public let event: AdaptableQueryResultItem
-}
-
-/// TopN queries return a sorted set of results for the values in a given dimension according to some criteria.
-///
-/// Conceptually, they can be thought of as an approximate GroupByQuery over a single dimension with an Ordering spec.
-/// TopNs are much faster and resource efficient than GroupBys for this use case. These types of queries take a topN query
-///  object and return an array of JSON objects where each object represents a value asked for by the topN query.
-public struct TopNQueryResult: Codable, Hashable, Equatable {
-    public init(rows: [TopNQueryResultRow], restrictions: [QueryTimeInterval]? = nil) {
-        self.rows = rows
-        self.restrictions = restrictions
-    }
-
-    public let restrictions: [QueryTimeInterval]?
-    public let rows: [TopNQueryResultRow]
-}
-
-public struct TopNQueryResultRow: Codable, Hashable, Equatable {
-    public init(timestamp: Date, result: [AdaptableQueryResultItem]) {
-        self.timestamp = timestamp
-        self.result = result
-    }
-
-    public let timestamp: Date
-    public let result: [AdaptableQueryResultItem]
-}
-
-public struct ScanQueryResult: Codable, Hashable, Equatable {
-    public init(rows: [ScanQueryResultRow], restrictions: [QueryTimeInterval]? = nil) {
-        self.restrictions = restrictions
-        self.rows = rows
-    }
-
-    public let restrictions: [QueryTimeInterval]?
-    public let rows: [ScanQueryResultRow]
-}
-
-public struct ScanQueryResultRow: Codable, Hashable, Equatable {
-    public init(
-        segmentId: String? = nil,
-        columns: [String],
-        events: [AdaptableQueryResultItem],
-        rowSignature: [ScanQueryRowSignatureRow]
-    ) {
-        self.segmentId = segmentId
-        self.columns = columns
-        self.events = events
-        self.rowSignature = rowSignature
-    }
-
-    public let segmentId: String?
-    public let columns: [String]
-    public let events: [AdaptableQueryResultItem]
-    public let rowSignature: [ScanQueryRowSignatureRow]
-}
-
-public struct ScanQueryRowSignatureRow: Codable, Hashable, Equatable {
-    public init(name: String, type: String) {
-        self.name = name
-        self.type = type
-    }
-
-    public let name: String
-    public let type: String?
-}
-
 /// Represents a JSON object that can contain string values (dimensions), double values (dimensions) and null values.
 public struct AdaptableQueryResultItem: Codable, Hashable, Equatable {
     public init(metrics: [String: DoubleWrapper], dimensions: [String: StringWrapper], nullValues: [String] = []) {
@@ -364,26 +256,6 @@ public struct AdaptableQueryResultItem: Codable, Hashable, Equatable {
             nil
         }
     }
-}
-
-public struct TimeBoundaryResult: Codable, Hashable, Equatable {
-    public init(rows: [TimeBoundaryResultRow], restrictions: [QueryTimeInterval]? = nil) {
-        self.restrictions = restrictions
-        self.rows = rows
-    }
-
-    public let restrictions: [QueryTimeInterval]?
-    public let rows: [TimeBoundaryResultRow]
-}
-
-public struct TimeBoundaryResultRow: Codable, Hashable, Equatable {
-    public init(timestamp: Date, result: [String: Date]) {
-        self.timestamp = timestamp
-        self.result = result
-    }
-
-    public let timestamp: Date
-    public let result: [String: Date]
 }
 
 // MARK: - Legacy Structs

--- a/Sources/DataTransferObjects/QueryResult/ScanQueryResult.swift
+++ b/Sources/DataTransferObjects/QueryResult/ScanQueryResult.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+public struct ScanQueryResult: Codable, Hashable, Equatable {
+    public init(rows: [ScanQueryResultRow], restrictions: [QueryTimeInterval]? = nil) {
+        self.restrictions = restrictions
+        self.rows = rows
+    }
+
+    public let restrictions: [QueryTimeInterval]?
+    public let rows: [ScanQueryResultRow]
+}
+
+public struct ScanQueryResultRow: Codable, Hashable, Equatable {
+    public init(
+        segmentId: String? = nil,
+        columns: [String],
+        events: [AdaptableQueryResultItem],
+        rowSignature: [ScanQueryRowSignatureRow]
+    ) {
+        self.segmentId = segmentId
+        self.columns = columns
+        self.events = events
+        self.rowSignature = rowSignature
+    }
+
+    public let segmentId: String?
+    public let columns: [String]
+    public let events: [AdaptableQueryResultItem]
+    public let rowSignature: [ScanQueryRowSignatureRow]
+}
+
+public struct ScanQueryRowSignatureRow: Codable, Hashable, Equatable {
+    public init(name: String, type: String) {
+        self.name = name
+        self.type = type
+    }
+
+    public let name: String
+    public let type: String?
+}

--- a/Sources/DataTransferObjects/QueryResult/TimeBoundaryResult.swift
+++ b/Sources/DataTransferObjects/QueryResult/TimeBoundaryResult.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+public struct TimeBoundaryResult: Codable, Hashable, Equatable {
+    public init(rows: [TimeBoundaryResultRow], restrictions: [QueryTimeInterval]? = nil) {
+        self.restrictions = restrictions
+        self.rows = rows
+    }
+
+    public let restrictions: [QueryTimeInterval]?
+    public let rows: [TimeBoundaryResultRow]
+}
+
+public struct TimeBoundaryResultRow: Codable, Hashable, Equatable {
+    public init(timestamp: Date, result: [String: Date]) {
+        self.timestamp = timestamp
+        self.result = result
+    }
+
+    public let timestamp: Date
+    public let result: [String: Date]
+}

--- a/Sources/DataTransferObjects/QueryResult/TimeSeriesQueryResult.swift
+++ b/Sources/DataTransferObjects/QueryResult/TimeSeriesQueryResult.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+public struct TimeSeriesQueryResult: Codable, Hashable, Equatable {
+    public init(rows: [TimeSeriesQueryResultRow], restrictions: [QueryTimeInterval]? = nil) {
+        self.rows = rows
+        self.restrictions = restrictions
+    }
+
+    public let restrictions: [QueryTimeInterval]?
+    public let rows: [TimeSeriesQueryResultRow]
+}
+
+/// Time series queries return an array of JSON objects, where each object represents a value as described in the time-series query.
+/// For instance, the daily average of a dimension for the last one month.
+public struct TimeSeriesQueryResultRow: Codable, Hashable, Equatable {
+    public init(timestamp: Date, result: [String: DoubleWrapper]) {
+        self.timestamp = timestamp
+        self.result = result
+    }
+
+    public let timestamp: Date?
+    public let result: [String: DoubleWrapper?]
+}

--- a/Sources/DataTransferObjects/QueryResult/TopNQueryResult.swift
+++ b/Sources/DataTransferObjects/QueryResult/TopNQueryResult.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// TopN queries return a sorted set of results for the values in a given dimension according to some criteria.
+///
+/// Conceptually, they can be thought of as an approximate GroupByQuery over a single dimension with an Ordering spec.
+/// TopNs are much faster and resource efficient than GroupBys for this use case. These types of queries take a topN query
+///  object and return an array of JSON objects where each object represents a value asked for by the topN query.
+public struct TopNQueryResult: Codable, Hashable, Equatable {
+    public init(rows: [TopNQueryResultRow], restrictions: [QueryTimeInterval]? = nil) {
+        self.rows = rows
+        self.restrictions = restrictions
+    }
+
+    public let restrictions: [QueryTimeInterval]?
+    public let rows: [TopNQueryResultRow]
+}
+
+public struct TopNQueryResultRow: Codable, Hashable, Equatable {
+    public init(timestamp: Date, result: [AdaptableQueryResultItem]) {
+        self.timestamp = timestamp
+        self.result = result
+    }
+
+    public let timestamp: Date
+    public let result: [AdaptableQueryResultItem]
+}

--- a/Tests/QueryTests/QueryTimeIntervalTests.swift
+++ b/Tests/QueryTests/QueryTimeIntervalTests.swift
@@ -38,4 +38,60 @@ final class QueryTimeIntervalTests: XCTestCase {
             ]
         )
     }
+
+    func testQueryTimeIntervalsContainerTimeSegments() throws {
+        let timeIntervalContainer = QueryTimeIntervalsContainer(type: .intervals, intervals: [
+            QueryTimeInterval(
+                beginningDate: Date(iso8601String: "2022-07-28T17:21:00.000Z")!,
+                endDate: Date(iso8601String: "2022-08-01T11:30:00.000Z")!
+            ),
+            QueryTimeInterval(
+                beginningDate: Date(iso8601String: "2022-07-29T17:21:00.000Z")!,
+                endDate: Date(iso8601String: "2022-08-03T11:30:00.000Z")!
+            ),
+        ])
+
+        let granularity = QueryGranularity.day
+        let segments = try timeIntervalContainer.timeSegments(with: granularity)
+        XCTAssertEqual(
+            segments,
+            [
+                .init(beginningDate: .init(iso8601String: "2022-07-28T00:00:00.000Z")!, duration: .day),
+                .init(beginningDate: .init(iso8601String: "2022-07-29T00:00:00.000Z")!, duration: .day),
+                .init(beginningDate: .init(iso8601String: "2022-07-30T00:00:00.000Z")!, duration: .day),
+                .init(beginningDate: .init(iso8601String: "2022-07-31T00:00:00.000Z")!, duration: .day),
+                .init(beginningDate: .init(iso8601String: "2022-08-01T00:00:00.000Z")!, duration: .day),
+                .init(beginningDate: .init(iso8601String: "2022-08-02T00:00:00.000Z")!, duration: .day),
+                .init(beginningDate: .init(iso8601String: "2022-08-03T00:00:00.000Z")!, duration: .day),
+            ]
+        )
+    }
+
+    func testQueryTimeIntervalsContainerInitWithTimeSegments() throws {
+        let timeIntervalContainer = try QueryTimeIntervalsContainer(type: .intervals, timeSegments: [
+            .init(beginningDate: .init(iso8601String: "2022-07-28T00:00:00.000Z")!, duration: .day),
+            .init(beginningDate: .init(iso8601String: "2022-07-29T00:00:00.000Z")!, duration: .day),
+            // missing a day on purpose
+            .init(beginningDate: .init(iso8601String: "2022-07-31T00:00:00.000Z")!, duration: .day),
+            .init(beginningDate: .init(iso8601String: "2022-08-01T00:00:00.000Z")!, duration: .day),
+            .init(beginningDate: .init(iso8601String: "2022-08-02T00:00:00.000Z")!, duration: .day),
+            .init(beginningDate: .init(iso8601String: "2022-08-03T00:00:00.000Z")!, duration: .day),
+        ])
+
+        XCTAssertEqual(
+            timeIntervalContainer.intervals,
+            [
+                // Intervals' beginnings are inclusive, and the endings are exclusive
+                .init(
+                    beginningDate: .init(iso8601String: "2022-07-28T00:00:00.000Z")!,
+                    endDate: .init(iso8601String: "2022-07-30T00:00:00.000Z")!
+                ),
+
+                .init(
+                    beginningDate: .init(iso8601String: "2022-07-31T00:00:00.000Z")!,
+                    endDate: .init(iso8601String: "2022-08-04T00:00:00.000Z")!
+                ),
+            ]
+        )
+    }
 }

--- a/Tests/QueryTests/QueryTimeIntervalTests.swift
+++ b/Tests/QueryTests/QueryTimeIntervalTests.swift
@@ -17,4 +17,25 @@ final class QueryTimeIntervalTests: XCTestCase {
     func testDecodingQueryTimeInterval() throws {
         _ = try JSONDecoder.telemetryDecoder.decode(QueryTimeIntervalsContainer.self, from: exampleData)
     }
+
+    func testTimeSegmentsWithGranularity() throws {
+        let timeInterval = QueryTimeInterval(
+            beginningDate: Date(iso8601String: "2022-07-28T17:21:00.000Z")!,
+            endDate: Date(iso8601String: "2022-08-03T11:30:00.000Z")!
+        )
+        let granularity = QueryGranularity.day
+        let segments = try timeInterval.timeSegments(with: granularity)
+        XCTAssertEqual(
+            segments,
+            [
+                .init(beginningDate: .init(iso8601String: "2022-07-28T00:00:00.000Z")!, duration: .day),
+                .init(beginningDate: .init(iso8601String: "2022-07-29T00:00:00.000Z")!, duration: .day),
+                .init(beginningDate: .init(iso8601String: "2022-07-30T00:00:00.000Z")!, duration: .day),
+                .init(beginningDate: .init(iso8601String: "2022-07-31T00:00:00.000Z")!, duration: .day),
+                .init(beginningDate: .init(iso8601String: "2022-08-01T00:00:00.000Z")!, duration: .day),
+                .init(beginningDate: .init(iso8601String: "2022-08-02T00:00:00.000Z")!, duration: .day),
+                .init(beginningDate: .init(iso8601String: "2022-08-03T00:00:00.000Z")!, duration: .day),
+            ]
+        )
+    }
 }


### PR DESCRIPTION
This is an attempt to try out various ways of caching individual result rows for query results.

- Time series query results have a granularity as defined by the query, and each `row` has a `timestamp`
- Top N query results have a granularity as defined by the query, and each `row` has a `timestamp`
- GroupBy query results have a granularity as defined by the query, and each `row` has a `timestamp`

so these are possible candidates for a way of caching where we cache individual rows and only calculate the ones that are missing or outdated. (The druid server could more accurately tell which rows are outdated, but we're ignoring that for the sake of experiment and simplicity.)

## Process

1. a query comes in, it contains at least one relative interval or absolute interval
2. we generate `IntervalIndependentHash`, a hash from a copy of the query where we remove all intervals, because intervals are irrelevant for this type of caching
3. we generate a list of all time segments we need to fulfill the query inside its intervals 
4. for each time segment, we query the cache for `IntervalIndependentHash` + `granularity` + `window` + `iso8601 date` for existing rows
5. we generate new intervals for all missing rows
6. we run a query with these intervals
7. we store all rows that we don't deem volatile in the cache
8. we build and return a full query result

This can be enhanced later with windowed caching where we cache complete results for fixed, non-overlapping time windows (e.g. per-day, per-week blocks).


## Tasks

- [x] implement `Query.intervalIndependentHash`
- [x] implement `TimeInterval.timeSegments(with: granularity)`
- [x] implement methods of generating new time intervals from old timeintervals minus time segments (should time segments be their own struct?)
- [ ] implement combining of query results 